### PR TITLE
Create lxc container with network error

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -344,7 +344,7 @@ pct create "${CONTAINER_ID}" "${TEMPLATE_LOCATION}" \
     -onboot 1 \
     -features nesting=1 \
     -hostname "${HOSTNAME}" \
-    -net0 name=${NET_INTERFACE},bridge=${NET_BRIDGE},dhcp=1 \
+    -net0 name=${NET_INTERFACE},bridge=${NET_BRIDGE},ip=dhcp \
     -ostype "${CONTAINER_OS_TYPE}" \
     -password "${HOSTPASS}" \
     -storage "${STORAGE}" || fatal "Failed to create LXC container!"


### PR DESCRIPTION
Fix LXC container creation by changing `dhcp=1` to `ip=dhcp` in the `net0` parameter.

---
<a href="https://cursor.com/background-agent?bcId=bc-0eb2be64-6840-4edc-8cc9-a80b056b9c13">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0eb2be64-6840-4edc-8cc9-a80b056b9c13">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

