### PR TITLE
Handle LXC container creation network parameter failure

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -344,7 +344,7 @@ pct create "${CONTAINER_ID}" "${TEMPLATE_LOCATION}" \
     -onboot 1 \
     -features nesting=1 \
     -hostname "${HOSTNAME}" \
-    -net0 name=${NET_INTERFACE},bridge=${NET_BRIDGE},dhcp=1 \
+    -net0 name=${NET_INTERFACE},bridge=${NET_BRIDGE},ip=dhcp \
     -ostype "${CONTAINER_OS_TYPE}" \
     -password "${HOSTPASS}" \
     -storage "${STORAGE}" || fatal "Failed to create LXC container!"


### PR DESCRIPTION
Fix LXC container creation by changing `dhcp=1` to `ip=dhcp` for network configuration.

---
<a href="https://cursor.com/background-agent?bcId=bc-439fb600-b4ea-4fc6-a97c-d8fb2f4b08c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-439fb600-b4ea-4fc6-a97c-d8fb2f4b08c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

