### PR TITLE
Handle LXC container creation network parameter failure

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -61,7 +61,7 @@ NET_BRIDGE=$(ip route | grep default | awk '{print $3}' | head -n1 | cut -d'.' -
 
 ### DHCP Configuration
 ```bash
--net0 name=${NET_INTERFACE},bridge=${NET_BRIDGE},dhcp=1
+-net0 name=${NET_INTERFACE},bridge=${NET_BRIDGE},ip=dhcp
 ```
 
 ## Validation Results

--- a/setup.sh
+++ b/setup.sh
@@ -344,7 +344,7 @@ pct create "${CONTAINER_ID}" "${TEMPLATE_LOCATION}" \
     -onboot 1 \
     -features nesting=1 \
     -hostname "${HOSTNAME}" \
-    -net0 name=${NET_INTERFACE},bridge=${NET_BRIDGE},dhcp=1 \
+    -net0 name=${NET_INTERFACE},bridge=${NET_BRIDGE},ip=dhcp \
     -ostype "${CONTAINER_OS_TYPE}" \
     -password "${HOSTPASS}" \
     -storage "${STORAGE}" || fatal "Failed to create LXC container!"

--- a/setup.sh
+++ b/setup.sh
@@ -326,16 +326,51 @@ if [ -z "$NET_BRIDGE" ] || [[ ! "$NET_BRIDGE" =~ ^vmbr[0-9]+$ ]]; then
     warn "Could not detect network bridge, using default: $NET_BRIDGE"
 fi
 
-# Get IP configuration - try DHCP first, fallback to static
+# Get IP configuration
 info "Network interface: $NET_INTERFACE, Bridge: $NET_BRIDGE"
-info "IP configuration will use DHCP by default. You can configure static IP later in the container."
+echo -e "\nNetwork Configuration:"
+echo "Enter an IP address for the container, or type 'auto' for DHCP."
+read -p "IP Address (192.168.1.29 or auto): " IP_CONFIG
+
+# Configure network settings based on user input
+if [ -z "$IP_CONFIG" ]; then
+    IP_CONFIG="192.168.1.29"
+fi
+
+if [ "$IP_CONFIG" = "auto" ] || [ "$IP_CONFIG" = "dhcp" ]; then
+    info "Using DHCP for network configuration"
+    NETWORK_CONFIG="name=${NET_INTERFACE},bridge=${NET_BRIDGE},ip=dhcp"
+else
+    # For static IP, we need subnet mask and gateway
+    if [[ "$IP_CONFIG" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        # IP without subnet mask provided, ask for it
+        read -p "Subnet mask (24): " SUBNET_MASK
+        if [ -z "$SUBNET_MASK" ]; then
+            SUBNET_MASK="24"
+        fi
+        IP_WITH_SUBNET="${IP_CONFIG}/${SUBNET_MASK}"
+    else
+        # IP already includes subnet mask
+        IP_WITH_SUBNET="$IP_CONFIG"
+    fi
+    
+    # Ask for gateway
+    DEFAULT_GATEWAY=$(echo "$IP_CONFIG" | cut -d'.' -f1-3).1
+    read -p "Gateway ($DEFAULT_GATEWAY): " GATEWAY
+    if [ -z "$GATEWAY" ]; then
+        GATEWAY="$DEFAULT_GATEWAY"
+    fi
+    
+    info "Using static IP: $IP_WITH_SUBNET with gateway: $GATEWAY"
+    NETWORK_CONFIG="name=${NET_INTERFACE},bridge=${NET_BRIDGE},ip=${IP_WITH_SUBNET},gw=${GATEWAY}"
+fi
 
 # Create the container
 info "Creating LXC container..."
 CONTAINER_ARCH=$(dpkg --print-architecture)
 info "Using ARCH: ${CONTAINER_ARCH}"
 
-# Create container with DHCP network configuration
+# Create container with configured network settings
 pct create "${CONTAINER_ID}" "${TEMPLATE_LOCATION}" \
     -arch "${CONTAINER_ARCH}" \
     -cores 2 \
@@ -344,7 +379,7 @@ pct create "${CONTAINER_ID}" "${TEMPLATE_LOCATION}" \
     -onboot 1 \
     -features nesting=1 \
     -hostname "${HOSTNAME}" \
-    -net0 name=${NET_INTERFACE},bridge=${NET_BRIDGE},ip=dhcp \
+    -net0 ${NETWORK_CONFIG} \
     -ostype "${CONTAINER_OS_TYPE}" \
     -password "${HOSTPASS}" \
     -storage "${STORAGE}" || fatal "Failed to create LXC container!"


### PR DESCRIPTION
Fix `pct create` network configuration by changing `dhcp=1` to `ip=dhcp` to resolve parameter verification errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-1f1cad43-e086-4a97-acb8-16fe82c184a8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1f1cad43-e086-4a97-acb8-16fe82c184a8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

